### PR TITLE
Removing obsolete reference to *mustache-output*.

### DIFF
--- a/mustache.lisp
+++ b/mustache.lisp
@@ -577,10 +577,7 @@ The syntax grammar is:
 variable before calling mustache-rendering and friends. Default is
 *standard-output*.")
 
-(defun %output ()
-  (if (eq *mustache-output* *real-standard-output*)
-      *output-stream*
-      *mustache-output*))
+(defun %output () *output-stream*)
 
 (defgeneric print-data (data escapep context))
 


### PR DESCRIPTION
This is meant to address Issue #27. https://github.com/kanru/cl-mustache/issues/27.